### PR TITLE
Remove x api ident from headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testrail-api-client",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "description": "JavaScript client for TestRail API",
   "main": "index.js",
   "files": [

--- a/src/testrail.ts
+++ b/src/testrail.ts
@@ -9,7 +9,7 @@ import { TestRailOptions, TestRailResult } from "./testrail.interface";
 export class TestRailClient {
     private indexUri = "/index.php?";
     public uri: String = `${this.indexUri}/api/v2`;
-    private commonHeaders = { 'Content-Type': 'application/json', 'x-api-ident': 'beta' };
+    private commonHeaders = { 'Content-Type': 'application/json' };
     private axiosInstance: AxiosInstance;
 
     private agent = new https.Agent({


### PR DESCRIPTION
With TestRail v9.0 the parameter x-api-ident in the headers is not supported anymore causing the request to fails with RC500