### PR TITLE
Add automated versioning on merge to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+# Bumps the version, generates a changelog, and creates a GitHub Release
+# based on Conventional Commits on every push to master.
+# semantic-release runs in its own isolated install (not the project's
+# node_modules) to avoid dependency conflicts with the project's toolchain.
+# The actual npm publish happens in npmpublish.yml, triggered by that release.
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: yarn install
+      - run: yarn build
+      - run: yarn test
+      - name: Release
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          extra_plugins: |
+            @semantic-release/changelog@6
+            @semantic-release/git@10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,14 @@
+{
+  "branches": ["master"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
+    ["@semantic-release/npm", { "npmPublish": false }],
+    ["@semantic-release/git", {
+      "assets": ["package.json", "CHANGELOG.md"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }],
+    "@semantic-release/github"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "tsc": "tsc",
     "clean": "rimraf dist",
     "build": "yarn run clean && yarn run tsc",
-    "precommit": "yarn version --patch",
     "test": "mocha",
     "coverage": "istanbul cover --report html node_modules/mocha/bin/_mocha --check-leaks",
     "coverageci": "istanbul cover node_modules/mocha/bin/_mocha && cat ./coverage/lcov.info | coveralls"


### PR DESCRIPTION
Adds a semantic-release workflow that analyzes Conventional Commits on push to master, bumps package.json, writes CHANGELOG.md, and creates a GitHub Release. The existing npmpublish.yml workflow is unchanged and continues to publish to npm when that release is created.

semantic-release runs via cycjimmy/semantic-release-action in an isolated install rather than as a project devDependency, avoiding a yargs/cliui hoisting conflict with mocha in this project's node_modules.

Removes the now-unused `precommit: yarn version --patch` script, which would otherwise conflict with automatic versioning.