### PR TITLE
fix: match semantic-release tagFormat to existing tag convention

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,6 @@
 {
   "branches": ["master"],
+  "tagFormat": "${version}",
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
The repo's existing release tags are plain "X.Y.Z" (e.g. 1.0.41), not the semantic-release default "vX.Y.Z". Without this, semantic-release found no matching prior release tags and reset versioning to 1.0.0 on the first run instead of continuing from 1.0.41.