### PR TITLE
fix: publish to npm on release published, not just created

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -3,7 +3,7 @@
 name: Node.js Package
 on:
   release:
-    types: [created]
+    types: [published]
 
 permissions:
   contents: read


### PR DESCRIPTION
GitHub's release event fires the "created" action only when a release is first saved as a draft. semantic-release's github plugin creates releases directly as published (non-draft), which fires "published" instead — so npmpublish.yml never ran for the automated releases (e.g. 1.0.43 was created but never published to npm).