### PR TITLE
fix: use a PAT to create releases so npmpublish.yml actually triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,7 @@ jobs:
             @semantic-release/changelog@6
             @semantic-release/git@10
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A PAT is required here, not secrets.GITHUB_TOKEN: GitHub does not
+          # trigger other workflows (e.g. npmpublish.yml's `release` event)
+          # for releases created using the default GITHUB_TOKEN.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
GitHub suppresses downstream workflow runs for events created with the default GITHUB_TOKEN, to prevent infinite workflow loops. Since semantic-release's github plugin was creating releases with secrets.GITHUB_TOKEN, npmpublish.yml's `on: release` trigger never fired for any automated release (1.0.43, 1.0.44 both show zero npmpublish.yml runs despite the release existing).

Requires a repo secret RELEASE_TOKEN: a fine-grained PAT scoped to
this repo with "Contents: Read and write" permission.